### PR TITLE
Implement Client.clearActivity

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -529,6 +529,12 @@ class RPCClient extends BaseClient {
     });
   }
 
+  /**
+   * Clears the currently set presence, if any. This will hide the "Playing X" message 
+   * displayed below the user's name.
+   * @param {number} The application's process ID. Defaults to the executing process' PID.
+   * @returns {Promise}
+   */
   clearActivity(pid = getPid()) {
     return this.request(RPCCommands.SET_ACTIVITY, {
       pid,

--- a/src/Client.js
+++ b/src/Client.js
@@ -532,7 +532,7 @@ class RPCClient extends BaseClient {
   /**
    * Clears the currently set presence, if any. This will hide the "Playing X" message 
    * displayed below the user's name.
-   * @param {number} pid The application's process ID. Defaults to the executing process' PID.
+   * @param {number} [pid] The application's process ID. Defaults to the executing process' PID.
    * @returns {Promise}
    */
   clearActivity(pid = getPid()) {

--- a/src/Client.js
+++ b/src/Client.js
@@ -529,6 +529,12 @@ class RPCClient extends BaseClient {
     });
   }
 
+  clearActivity(pid = getPid()) {
+    return this.request(RPCCommands.SET_ACTIVITY, {
+      pid,
+    });
+  }
+
   sendJoinInvite(user) {
     return this.request(RPCCommands.SEND_ACTIVITY_JOIN_INVITE, {
       user_id: user.id ? user.id : user,

--- a/src/Client.js
+++ b/src/Client.js
@@ -532,7 +532,7 @@ class RPCClient extends BaseClient {
   /**
    * Clears the currently set presence, if any. This will hide the "Playing X" message 
    * displayed below the user's name.
-   * @param {number} The application's process ID. Defaults to the executing process' PID.
+   * @param {number} pid The application's process ID. Defaults to the executing process' PID.
    * @returns {Promise}
    */
   clearActivity(pid = getPid()) {


### PR DESCRIPTION
A [while back](https://github.com/discordapp/discord-rpc/pull/104), Discord_ClearPresence was added to the native RPC library. This PR implements a clearActivity function that does the same thing.