### PR TITLE
Fixed trailing comma causing crashes on old chrome versions with electron

### DIFF
--- a/src/transports/websocket.js
+++ b/src/transports/websocket.js
@@ -21,7 +21,7 @@ class WebSocketTransport extends EventEmitter {
     const port = 6463 + (tries % 10);
     this.hostAndPort = `127.0.0.1:${port}`;
     const ws = this.ws = new WebSocket(
-      `ws://${this.hostAndPort}/?v=1&client_id=${this.client.clientId}`,
+      `ws://${this.hostAndPort}/?v=1&client_id=${this.client.clientId}`
     );
     ws.onopen = this.onOpen.bind(this);
     ws.onclose = ws.onerror = this.onClose.bind(this);


### PR DESCRIPTION
On old chrome versions (used for example on Electron), a trailing comma in websocket.js was causing syntax error leading to a crash.

![Proof](https://i.gyazo.com/26817a5c858d8c7e5e29e2ce6125f59e.png)