### PR TITLE
Add client_secret to authorization

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -212,6 +212,7 @@ class RPCClient extends EventEmitter {
     const response = await this.fetch('POST', '/oauth2/token', {
       data: new URLSearchParams({
         client_id: this.clientId,
+        client_secret: clientSecret,
         code,
         grant_type: 'authorization_code',
         redirect_uri: redirectUri,


### PR DESCRIPTION
Without `client_secret` field `access_token` won't be generated. It will trigger scope bug and won't save `access_token` for later usage.

Fixes https://github.com/discordjs/RPC/issues/55