### PR TITLE
Minor punctuation.

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -23,7 +23,7 @@ function subKey(event, args) {
  */
 class RPCClient extends EventEmitter {
   /**
-   * @param {RPCClientOptions} [options] Options for the client
+   * @param {RPCClientOptions} [options] Options for the client.
    * You must provide a transport
    */
   constructor(options = {}) {


### PR DESCRIPTION
The description of the RPCClient documentation (https://discord.js.org/#/docs/rpc/master/class/RPCClient) description reads: "Options for the client You must provide a transport"