### PR TITLE
Emit a disconnected event

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -102,7 +102,11 @@ class RPCClient extends EventEmitter {
         clearTimeout(timeout);
         resolve(this);
       });
-      this.transport.once('close', reject);
+      this.transport.once('close', () => {
+        this.emit("disconnected");
+        this._connectPromise = undefined;
+        reject();
+      });
       this.transport.connect().catch(reject);
     });
     return this._connectPromise;

--- a/src/client.js
+++ b/src/client.js
@@ -103,7 +103,7 @@ class RPCClient extends EventEmitter {
         resolve(this);
       });
       this.transport.once('close', () => {
-        this.emit("disconnected");
+        this.emit('disconnected');
         this._connectPromise = undefined;
         reject();
       });


### PR DESCRIPTION
Emit a disconnected event when the connection promise closes.
Reset the promise at the same time, so that you can reconnect.

Closes #42