### PR TITLE
Update to fit with newest 'ws' version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "node-fetch": "^2.3.0",
-    "ws": "^6.1.1"
+    "ws": "^7.1.0"
   },
   "peerDependencies": {
     "register-scheme": "github:devsnek/node-register-scheme"


### PR DESCRIPTION
I looked at 'ws' newest version (7.1.0), and it seems like nothing wrote in "src/transport/websocket.js" (where the module is required) is deprecated.
If someone could double check to be sure ...