### PR TITLE
RPCClient.selectTextChannel() does not take a force parameter

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -373,8 +373,8 @@ class RPCClient extends EventEmitter {
    * have explicit permission from the user.
    * @returns {Promise}
    */
-  selectTextChannel(id, { timeout, force = false } = {}) {
-    return this.request(RPCCommands.SELECT_TEXT_CHANNEL, { channel_id: id, timeout, force });
+  selectTextChannel(id, { timeout } = {}) {
+    return this.request(RPCCommands.SELECT_TEXT_CHANNEL, { channel_id: id, timeout });
   }
 
   /**


### PR DESCRIPTION
as the [discord developer portal documentation](https://discordapp.com/developers/docs/topics/rpc#selecttextchannel) says, SELECT_TEXT_CHANNEL does not take a force parameter. i removed the force parameter. RPCClient.selectTextChannel() works now.