### PR TITLE
fix: browser's websocket exception

### DIFF
--- a/src/transports/websocket.js
+++ b/src/transports/websocket.js
@@ -23,9 +23,7 @@ class WebSocketTransport extends EventEmitter {
 
     this.ws = new WebSocket(
       `ws://127.0.0.1:${port}/?v=1&client_id=${this.client.clientId}`,
-      {
-        origin: this.client.options.origin,
-      },
+      browser ? undefined : { origin: this.client.options.origin },
     );
     this.ws.onopen = this.onOpen.bind(this);
     this.ws.onclose = this.onClose.bind(this);


### PR DESCRIPTION
This change fixes an exception happening when using the RPC client on browser with the `websocket` transport, waiting for a single protocol string or an array of protocol strings instead of `ws` specific options.