### PR TITLE
Fix getIPCPath on darwin (macOS) under a parent process

### DIFF
--- a/src/transports/ipc.js
+++ b/src/transports/ipc.js
@@ -19,7 +19,11 @@ function getIPCPath(id) {
     return `\\\\?\\pipe\\discord-ipc-${id}`;
   }
   if (process.platform === 'darwin') {
-    return `${os.tmpdir()}/discord-ipc-${id}`;
+    let tmpdir = os.tmpdir();
+    if (!tmpdir.endsWith('/T')) {
+      tmpdir += '/..';
+    }
+    return `${tmpdir}/discord-ipc-${id}`;
   }
   const { env: { XDG_RUNTIME_DIR, TMPDIR, TMP, TEMP } } = process;
   const prefix = XDG_RUNTIME_DIR || TMPDIR || TMP || TEMP || '/tmp';

--- a/src/transports/ipc.js
+++ b/src/transports/ipc.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const os = require('os');
 const net = require('net');
 const EventEmitter = require('events');
 const fetch = require('node-fetch');
@@ -16,6 +17,9 @@ const OPCodes = {
 function getIPCPath(id) {
   if (process.platform === 'win32') {
     return `\\\\?\\pipe\\discord-ipc-${id}`;
+  }
+  if (process.platform === 'darwin') {
+    return `${os.tmpdir()}/discord-ipc-${id}`;
   }
   const { env: { XDG_RUNTIME_DIR, TMPDIR, TMP, TEMP } } = process;
   const prefix = XDG_RUNTIME_DIR || TMPDIR || TMP || TEMP || '/tmp';


### PR DESCRIPTION
On Darwin (macOS), under a parent process, the environment args might not be correctly passed and `os.tmpdir()` returns a subdirectory of the root temp dir. This PR therefore uses `os.tmpdir()` to ensure the environment args aren't modified and gets the parent of the subdirectory if it is detected that the returned temp directory is in a subdirectory.