### PR TITLE
fix: move peer deps to optional deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node-fetch": "^2.6.1",
     "ws": "^7.3.1"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "register-scheme": "github:devsnek/node-register-scheme"
   },
   "devDependencies": {


### PR DESCRIPTION
Node 15 tries to install peer dependencies by default, meaning that you have to either use `--legacy-peer-deps` or install build tools even if you don't need them. They should be moved to the optionalDependencies field instead.