### PR TITLE
setVoiceSettings functionality fails trying to change the mode Type

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -441,7 +441,7 @@ class RPCClient extends EventEmitter {
         volume: args.output.volume,
       } : undefined,
       mode: args.mode ? {
-        mode: args.mode.type,
+        type: args.mode.type,
         auto_threshold: args.mode.autoThreshold,
         threshold: args.mode.threshold,
         shortcut: args.mode.shortcut,


### PR DESCRIPTION
mode has a child keyword of 'type' in the documentation
the code had 'mode' as the keyword but was assigning 'args.mode.type'
changed the 'mode' keyword to 'type' to correct this issue to be able to change between Push To Talk and Voice Activity.