### PR TITLE
Add SubscriptionManager to handle and filter subscription callbacks

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -6,10 +6,7 @@ const fetch = require('node-fetch');
 const transports = require('./transports');
 const { RPCCommands, RPCEvents, RelationshipTypes } = require('./constants');
 const { pid: getPid, uuid } = require('./util');
-
-function subKey(event, args) {
-  return `${event}${JSON.stringify(args)}`;
-}
+const SubscriptionManager = require('./subscriptions');
 
 /**
  * @typedef {RPCClientOptions}
@@ -87,10 +84,10 @@ class RPCClient extends EventEmitter {
 
     /**
      * Map of current subscriptions
-     * @type {Map}
+     * @type {SubscriptionManager}
      * @private
      */
-    this._subscriptions = new Map();
+    this._subscriptions = new SubscriptionManager();
 
     this._connectPromise = undefined;
   }
@@ -191,11 +188,7 @@ class RPCClient extends EventEmitter {
       }
       this._expecting.delete(message.nonce);
     } else {
-      const subid = subKey(message.evt, message.args);
-      if (!this._subscriptions.has(subid)) {
-        return;
-      }
-      this._subscriptions.get(subid)(message.data);
+      this._subscriptions.fire(message.evt, message.data);
     }
   }
 
@@ -459,14 +452,19 @@ class RPCClient extends EventEmitter {
    * @returns {Promise<Function>}
    */
   captureShortcut(callback) {
-    const subid = subKey(RPCEvents.CAPTURE_SHORTCUT_CHANGE);
-    const stop = () => {
-      this._subscriptions.delete(subid);
+    let stop = null;
+    const onShortcutChange = ({ shortcut }) => callback(shortcut, stop);
+    stop = () => {
+      this._subscriptions.deregister(
+        RPCEvents.CAPTURE_SHORTCUT_CHANGE,
+        onShortcutChange,
+      );
       return this.request(RPCCommands.CAPTURE_SHORTCUT, { action: 'STOP' });
     };
-    this._subscriptions.set(subid, ({ shortcut }) => {
-      callback(shortcut, stop);
-    });
+    this._subscriptions.register(
+      RPCEvents.CAPTURE_SHORTCUT_CHANGE,
+      onShortcutChange,
+    );
     return this.request(RPCCommands.CAPTURE_SHORTCUT, { action: 'START' })
       .then(() => stop);
   }
@@ -659,11 +657,10 @@ class RPCClient extends EventEmitter {
       args = undefined;
     }
     return this.request(RPCCommands.SUBSCRIBE, args, event).then(() => {
-      const subid = subKey(event, args);
-      this._subscriptions.set(subid, callback);
+      const deregister = this._subscriptions.register(event, args, callback);
       return {
         unsubscribe: () => this.request(RPCCommands.UNSUBSCRIBE, args, event)
-          .then(() => this._subscriptions.delete(subid)),
+          .then(() => deregister()),
       };
     });
   }

--- a/src/constants.js
+++ b/src/constants.js
@@ -176,3 +176,14 @@ exports.RelationshipTypes = {
   PENDING_OUTGOING: 4,
   IMPLICIT: 5,
 };
+
+exports.ChannelTypes = {
+  GUILD_TEXT: 0,
+  DM: 1,
+  GUILD_VOICE: 2,
+  GROUP_DM: 3,
+  GUILD_CATEGORY: 4,
+  GUILD_NEWS: 5,
+  GUILD_STORE: 6,
+  GUILD_STAGE_VOICE: 13,
+};

--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const { RPCEvents } = require('./constants');
+
+/**
+ * @typedef {SubscriptionFilter}
+ * @type {function}
+ * @param {object} args
+ * @param {object} data
+ * @returns {boolean}
+ */
+
+/**
+ * @type {SubscriptionFilter}
+ */
+const guildStatusFilter = (args, data) => (
+  args
+  && data && data.guild
+  && args.guild_id === data.guild.id
+);
+/**
+ * @type {SubscriptionFilter}
+ */
+const messageFilter = (args, data) => (
+  args
+  && data
+  && args.channel_id === data.channel_id
+);
+
+/**
+ * @typedef SubscriptionFilters
+ * @type {object.<RPCEvent, SubscriptionFilter>}
+ */
+
+/**
+ * @type {SubscriptionFilters}
+ */
+const subscriptionFilters = {
+  [RPCEvents.GUILD_STATUS]: guildStatusFilter,
+  /* VOICE_STATE_CREATE/VOICE_STATE_UPDATE/VOICE_STATE_DELETE
+   * should have a check, but returned data does not have channel_id
+   */
+  [RPCEvents.MESSAGE_CREATE]: messageFilter,
+  [RPCEvents.MESSAGE_UPDATE]: messageFilter,
+  [RPCEvents.MESSAGE_DELETE]: messageFilter,
+  /* SPEAKING_START/SPEAKING_END should have checks,
+   * but no channel_id exists in payload
+   */
+};
+
+/**
+ * Manager for subscription arguments/callbacks
+ */
+class SubscriptionManager {
+  constructor() {
+    /**
+     * Map of subscriptions
+     * @type {Map}
+     * @private
+     */
+    this._subscriptions = new Map();
+  }
+
+  /**
+   * Register a callback to an event
+   * @param {string} evt Name of event
+   * @param {object} [args] Args for event
+   * @param {function} callback event callback
+   * @returns {function} deregistration function
+   */
+  register(evt, args, callback) {
+    if (!callback && typeof args === 'function') {
+      callback = args;
+      args = undefined;
+    }
+    if (!this._subscriptions.has(evt)) {
+      this._subscriptions.set(evt, []);
+    }
+    this._subscriptions.get(evt)
+      .push({ args, callback });
+
+    return () => this.deregister(evt, args, callback);
+  }
+
+  /**
+   * @param {string} evt Name of event
+   * @param {object} [args] Registered args
+   * @param {function} callback Registered callback
+   * @private
+   */
+  deregister(evt, args, callback) {
+    if (!callback && typeof args === 'function') {
+      callback = args;
+      args = undefined;
+    }
+
+    if (this._subscriptions.has(evt)) {
+      const subs = this._subscriptions.get(evt);
+      this._subscriptions.set(
+        evt,
+        subs.filter((sub) => !(sub.args === args && sub.callback === callback)),
+      );
+    }
+  }
+
+  /**
+   * Fire callbacks for a given message
+   * @param {string} evt Event name
+   * @param {Object} data Event data
+   */
+  fire(evt, data) {
+    if (this._subscriptions.has(evt)) {
+      let subs = this._subscriptions.get(evt);
+
+      // if possible, only fire matching subscriptions based on registration args
+      const filter = subscriptionFilters[evt];
+      if (filter) {
+        subs = subs.filter(({ args }) => filter(args, data));
+      }
+      subs.forEach(({ callback }) => callback(data));
+    }
+  }
+}
+
+module.exports = SubscriptionManager;


### PR DESCRIPTION
- Fixes issues with subscriptions not firing (#110, #121)
  - Adds filtering logic for some events with arguments (but not all, as payloads sometimes lack needed info)
- Add ChannelTypes constants