### PR TITLE
Fix `RPCLoginOptions` parameter docs

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -117,12 +117,13 @@ class RPCClient extends EventEmitter {
 
   /**
    * @typedef {RPCLoginOptions}
-   * @param {string} clientId Client ID
+   * @param {Snowflake} clientId Client ID
    * @param {string} [clientSecret] Client secret
    * @param {string} [accessToken] Access token
    * @param {string} [rpcToken] RPC token
-   * @param {string} [tokenEndpoint] Token endpoint
+   * @param {string} [redirectUri] OAuth2 redirect endpoint
    * @param {string[]} [scopes] Scopes to authorize with
+   * @param {string} [prompt] Authorization flow; `none` authorizes once, `consent` prompts for reapproval
    */
 
   /**


### PR DESCRIPTION
Documents `prompt` added by #137, renames `tokenEndpoint` to `redirectUri`, and specifies `clientId` as type `Snowflake`.

Currently, `tokenEndpoint` has no references in the code base, I believe this was intended to be `redirectUri` which is passed to [`authorize()`](https://github.com/discordjs/RPC/blob/12d87731ca00d19e8a2786d3a7650ee3d3b24dd8/src/client.js#L197-L223) from `login()` and otherwise absent from documentation.