### PR TITLE
allow activity types (fixes #146)

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -4,7 +4,7 @@ const EventEmitter = require('events');
 const { setTimeout, clearTimeout } = require('timers');
 const fetch = require('node-fetch');
 const transports = require('./transports');
-const { RPCCommands, RPCEvents, RelationshipTypes } = require('./constants');
+const { RPCCommands, RPCEvents, RelationshipTypes, ActivityTypes } = require('./constants');
 const { pid: getPid, uuid } = require('./util');
 
 function subKey(event, args) {
@@ -472,6 +472,7 @@ class RPCClient extends EventEmitter {
     let assets;
     let party;
     let secrets;
+    let type = ActivityTypes.PLAYING;
     if (args.startTimestamp || args.endTimestamp) {
       timestamps = {
         start: args.startTimestamp,
@@ -514,11 +515,15 @@ class RPCClient extends EventEmitter {
         spectate: args.spectateSecret,
       };
     }
+    if (args.type) {
+      type = args.type;
+    }
 
     return this.request(RPCCommands.SET_ACTIVITY, {
       pid,
       activity: {
         state: args.state,
+        type: type,
         details: args.details,
         timestamps,
         assets,

--- a/src/constants.js
+++ b/src/constants.js
@@ -176,3 +176,12 @@ exports.RelationshipTypes = {
   PENDING_OUTGOING: 4,
   IMPLICIT: 5,
 };
+
+exports.ActivityTypes = {
+  PLAYING:	0,
+  STREAMING:	1,
+  LISTENING:	2,
+  WATCHING:	3,
+  CUSTOM:	4,
+  COMPETING: 5
+}


### PR DESCRIPTION
This allows for sending activity types described [here](https://discord.com/developers/docs/topics/gateway#activity-object-activity-types).

I also included some handy constants to use.