### PR TITLE
docs: example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ```javascript
 const clientId = '287406016902594560';
-const scopes = ['rpc', 'rpc.api', 'messages.read'];
+const scopes = ['rpc', 'messages.read'];
 
 const client = new RPC.Client({ transport: 'websocket' });
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 const clientId = '287406016902594560';
 const scopes = ['rpc', 'messages.read'];
 
-const client = new RPC.Client({ transport: 'websocket' });
+const client = new RPC.Client({ transport: 'ipc' });
 
 client.on('ready', () => {
   console.log('Logged in as', client.application.name);


### PR DESCRIPTION
The scope rpc.api was removed and now throws an error, thus should be removed from the example.
Now uses ipc instead of websocket, since websocket requires whitelist afaik, thus it should be ipc as an example.