### PR TITLE
Fixed variable naming issue

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -133,7 +133,8 @@ class RPCClient extends EventEmitter {
    * @returns {Promise<RPCClient>}
    */
   async login(options = {}) {
-    let { clientId, accessToken } = options;
+    let values = Object.values(options);
+    let [clientId, accessToken] = values;
     await this.connect(clientId);
     if (!options.scopes) {
       this.emit('ready');


### PR DESCRIPTION
### This pull request aims to fix #173.

I have made appropriate changes to the client.js file in the src folder such that variable naming won't cause the 'connection closed' error. Developers writing code for custom rich presence can use any variable name instead of 'clientId' and 'accessToken' only.
For more info about the error, please check #173 

### Changes Made
- Removed the destructuring of object 'options' on line 136.
- An array called 'values' now stores the clientId and accessToken and this array is destructured appropriately