### PR TITLE
Fix parsing of IPC packets with multiple or partial messages

### DIFF
--- a/src/transports/ipc.js
+++ b/src/transports/ipc.js
@@ -88,34 +88,34 @@ function decode(socket, callback) {
       accumulatedData.payload = accumulatedData.payload.subarray(8); // Remove opcode and length
     }
 
-    if (accumulatedData.payload.length >= accumulatedData.expectedLength) {
-      // Accumulated data has the full payload and possibly the beginning of the next payload
-      const currentPayload = accumulatedData.payload.subarray(0, accumulatedData.expectedLength);
-      const nextPayload = accumulatedData.payload.subarray(accumulatedData.expectedLength);
-
-      accumulatedData.payload = nextPayload; // Keep remainder for next payload
-
-      try {
-        callback({
-          op: accumulatedData.op,
-          data: JSON.parse(currentPayload.toString('utf8')),
-        });
-
-        // Reset for next payload
-        accumulatedData.op = undefined;
-        accumulatedData.expectedLength = 0;
-      } catch (err) {
-        // Full payload has been received, but is not valid JSON
-        console.error('Error parsing payload:', err);
-
-        // Reset for next payload
-        accumulatedData.op = undefined;
-        accumulatedData.expectedLength = 0;
-
-        break;
-      }
-    } else {
+    if (accumulatedData.payload.length < accumulatedData.expectedLength) {
       // Full payload hasn't been received yet, wait for more data
+      break;
+    }
+
+    // Accumulated data has the full payload and possibly the beginning of the next payload
+    const currentPayload = accumulatedData.payload.subarray(0, accumulatedData.expectedLength);
+    const nextPayload = accumulatedData.payload.subarray(accumulatedData.expectedLength);
+
+    accumulatedData.payload = nextPayload; // Keep remainder for next payload
+
+    try {
+      callback({
+        op: accumulatedData.op,
+        data: JSON.parse(currentPayload.toString('utf8')),
+      });
+
+      // Reset for next payload
+      accumulatedData.op = undefined;
+      accumulatedData.expectedLength = 0;
+    } catch (err) {
+      // Full payload has been received, but is not valid JSON
+      console.error('Error parsing payload:', err);
+
+      // Reset for next payload
+      accumulatedData.op = undefined;
+      accumulatedData.expectedLength = 0;
+
       break;
     }
   }

--- a/src/transports/ipc.js
+++ b/src/transports/ipc.js
@@ -66,9 +66,10 @@ function encode(op, data) {
   return packet;
 }
 
-const working = {
-  full: '',
+const accumulatedData = {
+  payload: Buffer.alloc(0),
   op: undefined,
+  expectedLength: 0,
 };
 
 function decode(socket, callback) {
@@ -77,23 +78,46 @@ function decode(socket, callback) {
     return;
   }
 
-  let { op } = working;
-  let raw;
-  if (working.full === '') {
-    op = working.op = packet.readInt32LE(0);
-    const len = packet.readInt32LE(4);
-    raw = packet.slice(8, len + 8);
-  } else {
-    raw = packet.toString();
-  }
+  accumulatedData.payload = Buffer.concat([accumulatedData.payload, packet]);
 
-  try {
-    const data = JSON.parse(working.full + raw);
-    callback({ op, data }); // eslint-disable-line callback-return
-    working.full = '';
-    working.op = undefined;
-  } catch (err) {
-    working.full += raw;
+  while (accumulatedData.payload.length > 0) {
+    if (accumulatedData.expectedLength === 0) {
+      // We are at the start of a new payload
+      accumulatedData.op = accumulatedData.payload.readInt32LE(0);
+      accumulatedData.expectedLength = accumulatedData.payload.readInt32LE(4);
+      accumulatedData.payload = accumulatedData.payload.subarray(8); // Remove opcode and length
+    }
+
+    if (accumulatedData.payload.length >= accumulatedData.expectedLength) {
+      // Accumulated data has the full payload and possibly the beginning of the next payload
+      const currentPayload = accumulatedData.payload.subarray(0, accumulatedData.expectedLength);
+      const nextPayload = accumulatedData.payload.subarray(accumulatedData.expectedLength);
+
+      accumulatedData.payload = nextPayload; // Keep remainder for next payload
+
+      try {
+        callback({
+          op: accumulatedData.op,
+          data: JSON.parse(currentPayload.toString('utf8')),
+        });
+
+        // Reset for next payload
+        accumulatedData.op = undefined;
+        accumulatedData.expectedLength = 0;
+      } catch (err) {
+        // Full payload has been received, but is not valid JSON
+        console.error('Error parsing payload:', err);
+
+        // Reset for next payload
+        accumulatedData.op = undefined;
+        accumulatedData.expectedLength = 0;
+
+        break;
+      }
+    } else {
+      // Full payload hasn't been received yet, wait for more data
+      break;
+    }
   }
 
   decode(socket, callback);


### PR DESCRIPTION
## Observed bug

Sometimes creating subscriptions or sending commands through IPC would result in the promise never resolving, i.e. the message with the expected nonce never getting received.

## Reason

The original code to parse the received IPC packets:

https://github.com/discordjs/RPC/blob/9e7de2a6d917591f10a66389e62e1dc053c04fec/src/transports/ipc.js#L82-L100

The code assumes that a packet will contain at most one message.

The code will skip the processing of a message if a packet contains:

1. Two complete messages, or
2. The tail of one message and the head or entirety of the next message.

Practically speaking, we've only seen scenario 1 happen, but theoretically scenario 2 can happen as well.

### Scenario 1: A packet contains two complete messages

The packet buffer gets cropped to only contain the message:

https://github.com/discordjs/RPC/blob/9e7de2a6d917591f10a66389e62e1dc053c04fec/src/transports/ipc.js#L85

The rest of the buffer (which contains the second message) gets discarded. The second message never gets decoded.

### Scenario 2: A packet contains the tail of one message and the head or entirety of the next message

`working.full` already contains a part of the message from the previous packet.

This line assumes that the current packet will contain the tail of the message stored in `working.full`:

https://github.com/discordjs/RPC/blob/9e7de2a6d917591f10a66389e62e1dc053c04fec/src/transports/ipc.js#L87

However, because it contains the beginning or entirety of the next message, the parsing of the message fails on line 91, resulting in `working.full` containing one full message and at least partially a second message because of the concatenation on line 96:

https://github.com/discordjs/RPC/blob/9e7de2a6d917591f10a66389e62e1dc053c04fec/src/transports/ipc.js#L90-L97

Because `working.full` is now malformed, it will also affect the decoding of any subsequent messages, causing the packet data to continually be added to `working.full`.

## Fix

### Store the expected length of the current payload ([link](https://github.com/thedreamcorporation/discord-rpc/blob/f4fa49fec79e8b7a77e4f63c4f7709ea529013fc/src/transports/ipc.js#L69-L73))

```javascript
const accumulatedData = {
  payload: Buffer.alloc(0),
  op: undefined,
  expectedLength: 0,
};
```

### Treat all received packets as a stream of bytes

#### Concatenate all received packets ([link](https://github.com/thedreamcorporation/discord-rpc/blob/f4fa49fec79e8b7a77e4f63c4f7709ea529013fc/src/transports/ipc.js#L81))

```javascript
accumulatedData.payload = Buffer.concat([accumulatedData.payload, packet]);
```

#### Read a number of bytes according to the received message length ([link](https://github.com/thedreamcorporation/discord-rpc/blob/f4fa49fec79e8b7a77e4f63c4f7709ea529013fc/src/transports/ipc.js#L86-L88))

```javascript
accumulatedData.op = accumulatedData.payload.readInt32LE(0);
accumulatedData.expectedLength = accumulatedData.payload.readInt32LE(4);
accumulatedData.payload = accumulatedData.payload.subarray(8); // Remove opcode and length
```

#### Keep the remainder of a packet for decoding of next message ([link](https://github.com/thedreamcorporation/discord-rpc/blob/f4fa49fec79e8b7a77e4f63c4f7709ea529013fc/src/transports/ipc.js#L96-L100))

```javascript
// Accumulated data has the full payload and possibly the beginning of the next payload
const currentPayload = accumulatedData.payload.subarray(0, accumulatedData.expectedLength);
const nextPayload = accumulatedData.payload.subarray(accumulatedData.expectedLength);

accumulatedData.payload = nextPayload; // Keep remainder for next payload
```

### Keep processing the same packet if there's bytes left over after reading the length of the first complete message ([link](https://github.com/thedreamcorporation/discord-rpc/blob/f4fa49fec79e8b7a77e4f63c4f7709ea529013fc/src/transports/ipc.js#L83-L94))

```javascript
while (accumulatedData.payload.length > 0) {
  if (accumulatedData.expectedLength === 0) {
    // We are at the start of a new payload
    accumulatedData.op = accumulatedData.payload.readInt32LE(0);
    accumulatedData.expectedLength = accumulatedData.payload.readInt32LE(4);
    accumulatedData.payload = accumulatedData.payload.subarray(8); // Remove opcode and length
  }

  if (accumulatedData.payload.length < accumulatedData.expectedLength) {
    // Full payload hasn't been received yet, wait for more data
    break;
  }

  // ...
}
```
